### PR TITLE
fix: improve testprog code safety, signal handling, and documentation

### DIFF
--- a/lab03-running-testprog-for-the-first-time/README.md
+++ b/lab03-running-testprog-for-the-first-time/README.md
@@ -89,6 +89,14 @@ Now you may ask, is it more secure if you run it as a service? Let's try (don't 
 [james@selinux-dev selinux-hands-on-labs]$ fg
 sudo /usr/bin/testprog /etc/testprog.conf /var/run/testprog.pid
 ^C 
+```
+
+> **Note:** On newer distributions (e.g. Fedora 41+, RHEL 9+), `sudo` uses PTY mode by default, which may prevent Ctrl+C from reaching the process after `fg`. If Ctrl+C does not work, stop the process from another terminal using:
+> ```
+> sudo kill $(cat /var/run/testprog.pid)
+> ```
+
+```
 [james@selinux-dev selinux-hands-on-labs]$ sudo systemctl start testprog
 [james@selinux-dev selinux-hands-on-labs]$ sudo systemctl status testprog
 ● testprog.service - SELinux Test Program

--- a/testprog/testprog.c
+++ b/testprog/testprog.c
@@ -17,7 +17,18 @@
 #include <unistd.h>
 #include <string.h>
 #include <syslog.h>
+#include <signal.h>
 char s[11] = {"\nabcdefghij"};
+volatile sig_atomic_t keep_running = 1;
+/* volatile ensures compiler reads it every time instead of caching the value for mem optimization
+sig_atomic_t is a special integer type in signal.h. Guarantess read/write atomically (the CPU can
+update it in single instruction )
+*/
+void handle_signal(int sig)
+{
+	(void)sig; // For unused variable warning, avoiding printing of signal for code safety reasons
+	keep_running = 0;
+}
 
 #define FILENAME "testprog.conf"
 #define MAXBUF 1024
@@ -97,6 +108,8 @@ int main(int argc, char *argv[] )
 
 	setlogmask (LOG_UPTO (LOG_NOTICE));
 	openlog ("testprog", LOG_CONS | LOG_PID | LOG_NDELAY, LOG_LOCAL1);       
+	signal(SIGINT, handle_signal);
+	signal(SIGTERM, handle_signal);
 
 	char *config_path = FILENAME;
 	char *pid_path  = PIDFILE;
@@ -155,7 +168,7 @@ int main(int argc, char *argv[] )
 	syslog (LOG_NOTICE, "Iteration count: %d\n",x);
 
 	int i = 0;
-	while(i < x || x < 0)
+	while(keep_running && (i < x || x < 0))
 	{
 		FILE *file = fopen(configstruct.outputfile, "a");
 		fputs("\nHello World",file);

--- a/testprog/testprog.c
+++ b/testprog/testprog.c
@@ -34,6 +34,12 @@ struct config
 struct config get_config(char *filename)
 {
         struct config configstruct;
+		memset(&configstruct, 0, sizeof(configstruct));
+        /* Local variables are not initialized automatically, if function fails to open or
+        the config has fewer than 2 lines, configstruct.outputfile or configstruct.loopcount 
+        would contain whatever garbage was on the stack. memset here fills the entire struct
+        with zeros, so even on failure, the function call gets an empty string instead of 
+        unpredictable garbage memory.*/
         FILE *file = fopen (filename, "r");
 
         if (file != NULL)

--- a/testprog/testprog.c
+++ b/testprog/testprog.c
@@ -42,28 +42,40 @@ struct config get_config(char *filename)
         unpredictable garbage memory.*/
         FILE *file = fopen (filename, "r");
 
-        if (file != NULL)
+        if (file == NULL)
         {
-                char line[MAXBUF];
-                int i = 0;
+			printf("Could not open config file: %s\n", filename);
+			syslog(LOG_CRIT, "Could not open config file: %s\n", filename);
+			return configstruct;
+		} // Converted to a guarding clause for better readability(flattens the nesting) and early return
 
-                while(fgets(line, sizeof(line), file) != NULL)
-                {
-                        char *cfline;
-                        cfline = strstr((char *)line,DELIM);
-                        cfline = cfline + strlen(DELIM);
-   
-                        if (i == 0){
-                                memcpy(configstruct.outputfile,cfline,strlen(cfline));
-                                //printf("%s",configstruct.outputfile);
-                        } else if (i == 1){
-                                memcpy(configstruct.loopcount,cfline,strlen(cfline));
-                                //printf("%s",configstruct.loopcount);
-                        }
-                       
-                        i++;
-                } // End while
-        } // End if file
+        char line[MAXBUF];
+        int i = 0;
+
+		while(fgets(line, sizeof(line), file) != NULL)
+		{
+				char *cfline;
+				cfline = strstr((char *)line,DELIM);
+				if (cfline == NULL)				{
+					i++;
+					continue;
+				}
+				 /*Guarding clause for strstr returning null in case Delimeter '=' is not in config file.
+				 Earlier we were simply adding 1 to NULL, potentially leading to install crash. 
+				 Now we would simply skip the lines that don't have '=' delimeter. 
+				 */
+				cfline = cfline + strlen(DELIM);
+
+				if (i == 0){
+						memcpy(configstruct.outputfile,cfline,strlen(cfline));
+						//printf("%s",configstruct.outputfile);
+				} else if (i == 1){
+						memcpy(configstruct.loopcount,cfline,strlen(cfline));
+						//printf("%s",configstruct.loopcount);
+				}
+				
+				i++;
+		} // End while
        
                
         fclose(file);

--- a/testprog/testprog.c
+++ b/testprog/testprog.c
@@ -37,77 +37,74 @@ void handle_signal(int sig)
 
 struct config
 {
-   char outputfile[MAXBUF];
-   char loopcount[MAXBUF];
+	char outputfile[MAXBUF];
+	char loopcount[MAXBUF];
 };
 
 
 struct config get_config(char *filename)
 {
-        struct config configstruct;
-		memset(&configstruct, 0, sizeof(configstruct));
-        /* Local variables are not initialized automatically, if function fails to open or
-        the config has fewer than 2 lines, configstruct.outputfile or configstruct.loopcount 
-        would contain whatever garbage was on the stack. memset here fills the entire struct
-        with zeros, so even on failure, the function call gets an empty string instead of 
-        unpredictable garbage memory.*/
-        FILE *file = fopen (filename, "r");
+	struct config configstruct;
+	memset(&configstruct, 0, sizeof(configstruct));
+	/* Local variables are not initialized automatically, if function fails to open or
+	the config has fewer than 2 lines, configstruct.outputfile or configstruct.loopcount 
+	would contain whatever garbage was on the stack. memset here fills the entire struct
+	with zeros, so even on failure, the function call gets an empty string instead of 
+	unpredictable garbage memory.*/
+	FILE *file = fopen (filename, "r");
 
-        if (file == NULL)
-        {
-			printf("Could not open config file: %s\n", filename);
-			syslog(LOG_CRIT, "Could not open config file: %s\n", filename);
-			return configstruct;
-		} // Converted to a guarding clause for better readability(flattens the nesting) and early return
+	if (file == NULL)
+	{
+		printf("Could not open config file: %s\n", filename);
+		syslog(LOG_CRIT, "Could not open config file: %s\n", filename);
+		return configstruct;
+	} // Converted to a guarding clause for better readability(flattens the nesting) and early return
 
-        char line[MAXBUF];
-        int i = 0;
+	char line[MAXBUF];
+	int i = 0;
 
-		while(fgets(line, sizeof(line), file) != NULL)
+	while(fgets(line, sizeof(line), file) != NULL)
+	{
+		char *cfline;
+		cfline = strstr((char *)line,DELIM);
+		if (cfline == NULL)
 		{
-				char *cfline;
-				cfline = strstr((char *)line,DELIM);
-				if (cfline == NULL)
-				{
-					i++;
-					continue;
-				}
-				 /*Guarding clause for strstr returning null in case DELIM, '=' is not in config file.
-				 Earlier we were simply adding 1 to NULL, potentially leading to instant crash. 
-				 Now we would simply skip the lines that don't have '=' delimiter. 
-				 */
-				cfline = cfline + strlen(DELIM);
+			i++;
+			continue;
+		}
+		/*Guarding clause for strstr returning null in case DELIM, '=' is not in config file.
+		Earlier we were simply adding 1 to NULL, potentially leading to instant crash. 
+		Now we would simply skip the lines that don't have '=' delimiter. 
+		*/
+		cfline = cfline + strlen(DELIM);
 
-				size_t copy_len = strlen(cfline); //Used twice later, better to call only once.
-				if (copy_len >= MAXBUF)
-						copy_len = MAXBUF - 1;  // Preventing buffer overflow in case cfline is > 1024
+		size_t copy_len = strlen(cfline); //Used twice later, better to call only once.
+		if (copy_len >= MAXBUF)
+				copy_len = MAXBUF - 1;  // Preventing buffer overflow in case cfline is > 1024
 
-				if (i == 0){
-						memcpy(configstruct.outputfile,cfline,copy_len);
-						configstruct.outputfile[copy_len] = '\0'; //Null-terminate the string
-						//printf("%s",configstruct.outputfile);
-				} else if (i == 1){
-						memcpy(configstruct.loopcount,cfline,copy_len);
-						configstruct.loopcount[copy_len] = '\0'; //Null-terminate the string
-						//printf("%s",configstruct.loopcount);
-				}
-				
-				i++;
-		} // End while
-       
-               
-        fclose(file);
-       
-        return configstruct;
+		if (i == 0){
+				memcpy(configstruct.outputfile,cfline,copy_len);
+				configstruct.outputfile[copy_len] = '\0'; //Null-terminate the string
+				//printf("%s",configstruct.outputfile);
+		} else if (i == 1){
+				memcpy(configstruct.loopcount,cfline,copy_len);
+				configstruct.loopcount[copy_len] = '\0'; //Null-terminate the string
+				//printf("%s",configstruct.loopcount);
+		}
 
+		i++;
+	} // End while
+
+	fclose(file);
+	return configstruct;
 }
 
 int main(int argc, char *argv[] )
 {
-        struct config configstruct;
+	struct config configstruct;
 
 	setlogmask (LOG_UPTO (LOG_NOTICE));
-	openlog ("testprog", LOG_CONS | LOG_PID | LOG_NDELAY, LOG_LOCAL1);       
+	openlog ("testprog", LOG_CONS | LOG_PID | LOG_NDELAY, LOG_LOCAL1);
 	signal(SIGINT, handle_signal);
 	signal(SIGTERM, handle_signal);
 
@@ -122,7 +119,7 @@ int main(int argc, char *argv[] )
 	}
 
 	FILE *config_file = fopen( config_path, "r" );
-	
+
 	if ( config_file == NULL )
 	{
 		printf( "Could not open file: %s\n", config_path );
@@ -131,11 +128,11 @@ int main(int argc, char *argv[] )
 		return 1;
 	}
 	fclose(config_file);
-	
+
 	configstruct = get_config(config_path);
 	printf("Using configuration file: %s\n", config_path);
 	syslog (LOG_NOTICE, "Using configuration file: %s\n", config_path);
-    
+
 	FILE *pidfile = fopen( pid_path, "wb" );
 	if ( pidfile == NULL )
 	{
@@ -150,18 +147,16 @@ int main(int argc, char *argv[] )
 	syslog (LOG_NOTICE, "Wrote PID to %s\n", pid_path );
 
 
-	/* Code to trim our string and prevent bad chars in filename */
-	char* outputfilePtr = configstruct.outputfile;
+	/* Trim trailing newline/carriage return from output filename */
 	size_t len;
-	outputfilePtr += strspn(outputfilePtr, "\t\n\v\f\r ");
+	//Removed unused outputfilePtr and updated the comment above. Since it's never used anywhere.
 	len = strcspn(configstruct.outputfile, "\r\n");
 	configstruct.outputfile[len] = '\0';
 
 	printf("Writing output to: %s\n",configstruct.outputfile);
 	syslog (LOG_NOTICE, "Writing output to: %s\n",configstruct.outputfile);
-	
- 
-	/* Cast port as int */
+
+	/* Parse loop count as int */
 	int x;
 	x = atoi(configstruct.loopcount);
 	printf("Iteration count: %d\n",x);
@@ -173,12 +168,11 @@ int main(int argc, char *argv[] )
 		FILE *file = fopen(configstruct.outputfile, "a");
 		fputs("\nHello World",file);
 		fputs(s,file);
- 
+
 		fclose(file);
 		sleep(1);
 
 		i++;
-
 	}
 
 	closelog();

--- a/testprog/testprog.c
+++ b/testprog/testprog.c
@@ -166,10 +166,11 @@ int main(int argc, char *argv[] )
 	while(keep_running && (i < x || x < 0))
 	{
 		FILE *file = fopen(configstruct.outputfile, "a");
-		fputs("\nHello World",file);
-		fputs(s,file);
-
-		fclose(file);
+		if (file != NULL) {
+			fputs("\nHello World",file);
+			fputs(s,file);
+			fclose(file);
+		}
 		sleep(1);
 
 		i++;

--- a/testprog/testprog.c
+++ b/testprog/testprog.c
@@ -56,21 +56,28 @@ struct config get_config(char *filename)
 		{
 				char *cfline;
 				cfline = strstr((char *)line,DELIM);
-				if (cfline == NULL)				{
+				if (cfline == NULL)
+				{
 					i++;
 					continue;
 				}
-				 /*Guarding clause for strstr returning null in case Delimeter '=' is not in config file.
-				 Earlier we were simply adding 1 to NULL, potentially leading to install crash. 
-				 Now we would simply skip the lines that don't have '=' delimeter. 
+				 /*Guarding clause for strstr returning null in case DELIM, '=' is not in config file.
+				 Earlier we were simply adding 1 to NULL, potentially leading to instant crash. 
+				 Now we would simply skip the lines that don't have '=' delimiter. 
 				 */
 				cfline = cfline + strlen(DELIM);
 
+				size_t copy_len = strlen(cfline); //Used twice later, better to call only once.
+				if (copy_len >= MAXBUF)
+						copy_len = MAXBUF - 1;  // Preventing buffer overflow in case cfline is > 1024
+
 				if (i == 0){
-						memcpy(configstruct.outputfile,cfline,strlen(cfline));
+						memcpy(configstruct.outputfile,cfline,copy_len);
+						configstruct.outputfile[copy_len] = '\0'; //Null-terminate the string
 						//printf("%s",configstruct.outputfile);
 				} else if (i == 1){
-						memcpy(configstruct.loopcount,cfline,strlen(cfline));
+						memcpy(configstruct.loopcount,cfline,copy_len);
+						configstruct.loopcount[copy_len] = '\0'; //Null-terminate the string
 						//printf("%s",configstruct.loopcount);
 				}
 				

--- a/testprog/testprog.c
+++ b/testprog/testprog.c
@@ -98,45 +98,47 @@ int main(int argc, char *argv[] )
 	setlogmask (LOG_UPTO (LOG_NOTICE));
 	openlog ("testprog", LOG_CONS | LOG_PID | LOG_NDELAY, LOG_LOCAL1);       
 
-	if (argc < 2) {
-		// No arguments were passed
-        	configstruct = get_config(FILENAME);
-        	printf("Using configuration file: %s\n", FILENAME);
-		syslog (LOG_NOTICE, "Using configuration file: %s\n", FILENAME);
-		// We assume argv[2] is a pidfile to open
-		FILE *file = fopen( PIDFILE, "wb" );
-		fprintf(file, "%d\n", getpid());
-		fclose(file);
-		printf("Wrote PID to %s\n", PIDFILE );
-		syslog (LOG_NOTICE, "Wrote PID to %s\n", PIDFILE );
-	} else {
-	       	// We assume argv[1] is a config file to open
-	       	FILE *file = fopen( argv[1], "r" );
-	       
-	       	/* fopen returns 0, the NULL pointer, on failure */
-	       	if ( file == 0 )
-	       	{
-	       		printf( "Could not open file\n" );
-			syslog (LOG_CRIT, "Could not open file\n" );
-	       	}
-	       	else 
-	       	{
-			configstruct = get_config(argv[1]);
-        		printf("Using configuration file: %s\n", argv[1]);
-			syslog (LOG_NOTICE, "Using configuration file: %s\n", argv[1]);
-		}
-		fclose(file);
+	char *config_path = FILENAME;
+	char *pid_path  = PIDFILE;
 
-		// We assume argv[2] is a pidfile to open
-		FILE *pidfile = fopen( argv[2], "wb" );
-		fprintf(pidfile, "%d\n", getpid());
-		fclose(pidfile);
-		printf("Wrote PID to %s\n", argv[2] );
-		syslog (LOG_NOTICE, "Wrote PID to %s\n", argv[2] );
+	if (argc >= 2) {
+		config_path = argv[1];
+	}
+	if (argc >= 3) {
+		pid_path = argv[2];
 	}
 
+	FILE *config_file = fopen( config_path, "r" );
+	
+	if ( config_file == NULL )
+	{
+		printf( "Could not open file: %s\n", config_path );
+		syslog (LOG_CRIT, "Could not open file: %s\n", config_path );
+		closelog();
+		return 1;
+	}
+	fclose(config_file);
+	
+	configstruct = get_config(config_path);
+	printf("Using configuration file: %s\n", config_path);
+	syslog (LOG_NOTICE, "Using configuration file: %s\n", config_path);
+    
+	FILE *pidfile = fopen( pid_path, "wb" );
+	if ( pidfile == NULL )
+	{
+		printf( "Could not open PID file: %s\n", pid_path );
+		syslog (LOG_CRIT, "Could not open file: %s\n", pid_path );
+		closelog();
+		return 1;
+	}
+	fprintf(pidfile, "%d\n", getpid());
+	fclose(pidfile);
+	printf("Wrote PID to %s\n", pid_path);
+	syslog (LOG_NOTICE, "Wrote PID to %s\n", pid_path );
+
+
 	/* Code to trim our string and prevent bad chars in filename */
-      	char* outputfilePtr = configstruct.outputfile;
+	char* outputfilePtr = configstruct.outputfile;
 	size_t len;
 	outputfilePtr += strspn(outputfilePtr, "\t\n\v\f\r ");
 	len = strcspn(configstruct.outputfile, "\r\n");
@@ -146,10 +148,10 @@ int main(int argc, char *argv[] )
 	syslog (LOG_NOTICE, "Writing output to: %s\n",configstruct.outputfile);
 	
  
-        /* Cast port as int */
-        int x;
-        x = atoi(configstruct.loopcount);
-        printf("Iteration count: %d\n",x);
+	/* Cast port as int */
+	int x;
+	x = atoi(configstruct.loopcount);
+	printf("Iteration count: %d\n",x);
 	syslog (LOG_NOTICE, "Iteration count: %d\n",x);
 
 	int i = 0;
@@ -165,6 +167,7 @@ int main(int argc, char *argv[] )
 		i++;
 
 	}
- 
-return 0;
+
+	closelog();
+	return 0;
 }


### PR DESCRIPTION
## Summary
 - Initialize config struct with memset to prevent uninitialized memory access
 - Add guard clauses and NULL checks in get_config() (fopen, strstr) and main() (argv handling, fopen)
 - Add buffer overflow protection by clamping memcpy length to MAXBUF-1 with explicit null terminators
 - Add SIGINT/SIGTERM signal handling for graceful shutdown
 - Guard fopen in main loop to prevent segfault when running without write permissions
 - Fix misleading comment, remove unused variable, normalize indentation
 - Add note to lab03 README about sudo PTY mode on newer Fedora release preventing Ctrl+C

## Test plan
 - Compile with gcc -o testprog testprog.c
 - Run via sudo make install && sudo systemctl start testprog -- verify normal operation
 - Run without sudo to verify no segfault (fopen NULL check in loop)
 - Send SIGTERM/SIGINT via kill to verify graceful shutdown
