### PR TITLE
docs: fix typo in lab14 and add sudo PTY warnings in lab03, lab16

### DIFF
--- a/lab03-running-testprog-for-the-first-time/README.md
+++ b/lab03-running-testprog-for-the-first-time/README.md
@@ -229,6 +229,14 @@ And through systemd:
 [james@selinux-dev selinux-hands-on-labs]$ fg
 sudo /usr/bin/testprog /etc/testprog.conf /var/run/testprog.pid
 ^C
+```
+
+> **Note:** On newer distributions (e.g. Fedora 41+, RHEL 9+), `sudo` uses PTY mode by default, which may prevent Ctrl+C from reaching the process after `fg`. If Ctrl+C does not work, stop the process from another terminal using:
+> ```
+> sudo kill $(cat /var/run/testprog.pid)
+> ```
+
+```
 [james@selinux-dev selinux-hands-on-labs]$ sudo systemctl start testprog
 [james@selinux-dev selinux-hands-on-labs]$ ps -fZp $(cat /var/run/testprog.pid)
 system_u:system_r:unconfined_service_t:s0 root 11836 1  0 16:53 ?        00:00:00 /usr/bin/testprog /etc/testprog.conf /var/run/testprog.pid

--- a/lab14-networking/README.md
+++ b/lab14-networking/README.md
@@ -98,7 +98,7 @@ bind failed. Error
 [2]+  Exit 1                  sudo /usr/bin/testprog-net /etc/testprog-net.conf /var/run/testprog-net.pid
 ```
 
-Oh dear - we've failed. By now you will have guessed that SELinux also restricts access to network ports as well as files, `tty` devices and so on. This is over and above any firewall that you may or may not have running on your server - as with everything else we have explored so far it is an additional layer to the usual protections provided on a Linux system. Very that SELinux did indeed cause this:
+Oh dear - we've failed. By now you will have guessed that SELinux also restricts access to network ports as well as files, `tty` devices and so on. This is over and above any firewall that you may or may not have running on your server - as with everything else we have explored so far it is an additional layer to the usual protections provided on a Linux system. Verify that SELinux did indeed cause this:
 
 ```
 [james@selinux-dev lab14-networking]$ sudo grep testprog-net /var/log/audit/audit.log | grep AVC

--- a/lab16-booleans/README.md
+++ b/lab16-booleans/README.md
@@ -54,6 +54,14 @@ Se we can see above that our new boolean was created, and it is set to `on` as p
 [james@selinux-dev lab16-booleans]$ fg
 sudo /usr/bin/testprog-net /etc/testprog-net.conf /var/run/testprog-net.pid
 ^C
+```
+
+> **Note:** On newer distributions (e.g. Fedora 41+, RHEL 9+), `sudo` uses PTY mode by default, which may prevent Ctrl+C from reaching the process after `fg`. If Ctrl+C does not work, stop the process from another terminal using:
+> ```
+> sudo kill $(cat /var/run/testprog-net.pid)
+> ```
+
+```
 [james@selinux-dev lab16-booleans]$ sudo setsebool allow_testprog_use_network=off
 [james@selinux-dev lab16-booleans]$ getsebool -a | grep test
 allow_testprog_use_network --> off


### PR DESCRIPTION
## Summary

- Fix "Very" → "Verify" typo in lab14 README (line 101)
- Add note about `sudo` PTY mode preventing Ctrl+C after `fg` on newer distributions (Fedora 41+, RHEL 9+) in lab03 and lab16

On modern Fedora/RHEL, `sudo` defaults to PTY mode, which does not forward terminal signals (SIGINT, SIGTSTP) to the child process when brought to foreground with `fg`. This means the `fg` + `^C` pattern shown in the labs no longer works as described. The added notes suggest using `sudo kill $(cat /var/run/testprog.pid)` from another terminal as a workaround.

## Files changed

- `lab03-running-testprog-for-the-first-time/README.md` — sudo PTY note (second `fg` + `^C` instance)
- `lab14-networking/README.md` — typo fix
- `lab16-booleans/README.md` — sudo PTY note