### PR TITLE
docs: replace grep audit.log with ausearch for AVC searches

### DIFF
--- a/lab06-sealert-and-audit-log/README.md
+++ b/lab06-sealert-and-audit-log/README.md
@@ -17,11 +17,13 @@ type=USER_CMD msg=audit(1504795841.993:151): pid=11557 uid=1000 auid=0 ses=1 sub
 There's a huge amount of output including success messages so let's be a little more specific:
 
 ```
-[james@selinux-dev selinux-hands-on-labs]$ sudo grep AVC /var/log/audit/audit.log | grep testprog
+[james@selinux-dev selinux-hands-on-labs]$ sudo ausearch -m AVC -c testprog -ts today
 ...
 type=AVC msg=audit(1504818384.560:460): avc:  denied  { write } for  pid=12442 comm="testprog" name="testprog.pid" dev="tmpfs" ino=34664 scontext=unconfined_u:unconfined_r:testprog_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:var_run_t:s0 tclass=file
 ...
 ```
+
+> **Note:** `ausearch` is purpose-built for searching audit logs - `-m AVC` filters by message type and `-c` filters by command name. Use `-ts today` to limit results to the current day, `-ts recent` for the last 10 minutes, or omit `-ts` to search the full log. Add `-i` to convert timestamps and hex-encoded fields to human-readable format.
 
 There are still lots of lines of output, which really show how many parts of the system even our simple little testprog tries to access. It also shows you how finely grained SELinux's access control is - it goes beyond filesystem restrictions to controlling socket creation, `chr` file access, console output and so much more. I have cherry picked a simple example from the output on my development system to share above - what it's saying is:
 

--- a/lab11-interfaces/README.md
+++ b/lab11-interfaces/README.md
@@ -24,7 +24,7 @@ Now let's see what happens when it runs:
 ```
 [james@selinux-dev2 lab11-interfaces]$ sudo testcat /var/testprog/testprg.txt
 Segmentation fault (core dumped)
-[james@selinux-dev2 lab11-interfaces]$ sudo grep testcat /var/log/audit/audit.log | grep AVC
+[james@selinux-dev2 lab11-interfaces]$ sudo ausearch -m AVC -c testcat -ts today
 type=AVC msg=audit(1736175971.335:803): avc:  denied  { read write } for  pid=15978 comm="testcat" path="/dev/pts/0" dev="devpts" ino=3 scontext=unconfined_u:unconfined_r:testcat_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_devpts_t:s0 tclass=chr_file permissive=0
 type=AVC msg=audit(1736175971.335:803): avc:  denied  { read append } for  pid=15978 comm="testcat" path="/dev/pts/0" dev="devpts" ino=3 scontext=unconfined_u:unconfined_r:testcat_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_devpts_t:s0 tclass=chr_file permissive=0
 type=AVC msg=audit(1736175971.335:803): avc:  denied  { read append } for  pid=15978 comm="testcat" path="/dev/pts/0" dev="devpts" ino=3 scontext=unconfined_u:unconfined_r:testcat_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_devpts_t:s0 tclass=chr_file permissive=0

--- a/lab12-interfaces-part-2/README.md
+++ b/lab12-interfaces-part-2/README.md
@@ -17,7 +17,7 @@ Segmentation fault (core dumped)
 This might not look any better - we're still getting a segmentation fault - however if you query the audit log again, you'll see a reduced number of AVC denials for `testcat`:
 
 ```
-[james@selinux-dev lab12-interfaces-part-2]$ sudo grep testcat /var/log/audit/audit.log | grep AVC
+[james@selinux-dev lab12-interfaces-part-2]$ sudo ausearch -m AVC -c testcat -ts today
 ...
 type=AVC msg=audit(1736176260.532:844): avc:  denied  { map } for  pid=16049 comm="testcat" path="/usr/bin/testcat" dev="vda4" ino=25196736 scontext=unconfined_u:unconfined_r:testcat_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:testcat_exec_t:s0 tclass=file permissive=0
 ```

--- a/lab14-networking/README.md
+++ b/lab14-networking/README.md
@@ -101,7 +101,7 @@ bind failed. Error
 Oh dear - we've failed. By now you will have guessed that SELinux also restricts access to network ports as well as files, `tty` devices and so on. This is over and above any firewall that you may or may not have running on your server - as with everything else we have explored so far it is an additional layer to the usual protections provided on a Linux system. Very that SELinux did indeed cause this:
 
 ```
-[james@selinux-dev lab14-networking]$ sudo grep testprog-net /var/log/audit/audit.log | grep AVC
+[james@selinux-dev lab14-networking]$ sudo ausearch -m AVC -c testprog-net -ts today
 type=AVC msg=audit(1736177507.491:1052): avc:  denied  { create } for  pid=16360 comm="testprog-net" scontext=unconfined_u:unconfined_r:testprog_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:testprog_t:s0-s0:c0.c1023 tclass=tcp_socket permissive=0
 ```
 

--- a/lab15-allowing-networking/README.md
+++ b/lab15-allowing-networking/README.md
@@ -138,7 +138,7 @@ bind failed. Error
 This fails because our program tried to access a port that it didn't have permission to bind to. We can verify this from the audit logs:
 
 ```
-[james@selinux-dev lab15-allowing-networking]$ sudo grep AVC /var/log/audit/audit.log | grep testprog
+[james@selinux-dev lab15-allowing-networking]$ sudo ausearch -m AVC -c testprog-net -ts today
 type=AVC msg=audit(1736178782.210:1394): avc:  denied  { name_bind } for  pid=16914 comm="testprog-net" src=8235 scontext=unconfined_u:unconfined_r:testprog_t:s0-s0:c0.c1023 tcontext=system_u:object_r:unreserved_port_t:s0 tclass=tcp_socket permissive=0
 ```
 


### PR DESCRIPTION
## Summary

- Replace `grep AVC /var/log/audit/audit.log | grep <command>` with `ausearch -m AVC -c <command> -ts today` across labs 06, 11, 12, 14, and 15.
- Add a note in lab06 (where audit log searching is first introduced) explaining the `ausearch` flags (`-m`, `-c`, `-ts`) and the optional `-i` flag for human-readable output.

`ausearch` is purpose-built for searching audit logs and avoids fragile `grep` chains. The `-i` flag is documented but not used in the commands so that the existing sample output remains consistent.

## Files changed

- `lab06-sealert-and-audit-log/README.md` — command replacement + explanatory note
- `lab11-interfaces/README.md` — command replacement
- `lab12-interfaces-part-2/README.md` — command replacement
- `lab14-networking/README.md` — command replacement
- `lab15-allowing-networking/README.md` — command replacement

## Test plan

- [ ] Verify `ausearch -m AVC -c testprog -ts today` produces equivalent results to `grep AVC /var/log/audit/audit.log | grep testprog`
- [ ] Confirm the note in lab06 renders correctly in GitHub markdown