### PR TITLE
fix: add map permission for modern kernels and document denial differences

### DIFF
--- a/lab04-targeting-testprog/testprog.te
+++ b/lab04-targeting-testprog/testprog.te
@@ -25,7 +25,7 @@ files_type(testprog_exec_t);
 role unconfined_r types testprog_t;
 
 # Tell SELinux that testprog_exec_t is an entrypoint to the testprog_t domain
-allow testprog_t testprog_exec_t : file { ioctl read getattr lock execute execute_no_trans entrypoint open } ;
+allow testprog_t testprog_exec_t : file { ioctl read getattr lock execute execute_no_trans entrypoint open map } ;
 # Make the type transition from unconfined_t (i.e. user shell) to testprog_t
 type_transition unconfined_t testprog_exec_t : process testprog_t;
 # Explicitly allow the type transition we have just created

--- a/lab05-file-contexts/testprog.te
+++ b/lab05-file-contexts/testprog.te
@@ -25,7 +25,7 @@ files_type(testprog_exec_t);
 role unconfined_r types testprog_t;
 
 # Tell SELinux that testprog_exec_t is an entrypoint to the testprog_t domain
-allow testprog_t testprog_exec_t : file { ioctl read getattr lock execute execute_no_trans entrypoint open } ;
+allow testprog_t testprog_exec_t : file { ioctl read getattr lock execute execute_no_trans entrypoint open map } ;
 # Make the type transition from unconfined_t (i.e. user shell) to testprog_t
 type_transition unconfined_t testprog_exec_t : process testprog_t;
 # Explicitly allow the type transition we have just created

--- a/lab06-sealert-and-audit-log/README.md
+++ b/lab06-sealert-and-audit-log/README.md
@@ -29,6 +29,15 @@ The process with PID `12442` (named `testprog`) tried to `write` to a `file` obj
 
 Given this log we can also see how we could go about creating a full policy for our application so that it works like it used to, only confined to it's own context. We also see the power of SELinux - even though we ran `testprog` as root, it cannot write it's own PID file in `/var/run`, which is not what you would normally expect!
 
+> **Note for modern kernels (4.13+, e.g. Fedora 37+, RHEL 9+):** The AVC denials you see may differ from the examples above. Since kernel 4.13, the `map` permission is required for memory-mapping files, and the kernel denies it before the process can run any application code. On a modern system you are likely to see:
+>
+> - `{ map }` denied on `testprog_exec_t` (the binary cannot be loaded into memory)
+> - `{ read write }` denied on `user_devpts_t` (PTY/terminal access)
+> - `{ create }` denied on `unix_dgram_socket` (syslog socket)
+> - `{ write }` denied on `console_device_t`
+>
+> rather than the `var_run_t` denial shown above. This is because SELinux evaluates each access sequentially — the process segfaults on the `map` denial before it ever reaches the PID file write. The `map` permission has been added to the entrypoint allow rule in labs 04 and 05 to prevent this early segfault, so subsequent denials will be visible. The exact denials you encounter are not important at this stage — what matters is understanding how to diagnose them.
+
 # sealert
 
 Of course whilst this log file can be quite useful once you know how to interpret it, it's not always easy to decipher. The `sealert` tool can help you create new policies and fix issues like this, but it should be used with caution and awareness to create a truly secure application. 


### PR DESCRIPTION
## Summary

- Add `{ map }` to the entrypoint allow rule in `lab04/testprog.te` and `lab05/testprog.te`. On kernels 4.13+ (Fedora 37+, RHEL 9+), the `map` permission is required for memory-mapping executables. Without it, `testprog` segfaults immediately before any application code runs, preventing students from seeing the subsequent denials the labs are designed to teach.
- Add a note in `lab06/README.md` explaining why AVC denials on modern kernels differ from the CentOS 7 examples (PTY, console, syslog denials vs `var_run_t`).

## Files changed

- `lab04-targeting-testprog/testprog.te` — added `map` to entrypoint permission set
- `lab05-file-contexts/testprog.te` — same
- `lab06-sealert-and-audit-log/README.md` — added note about modern kernel denial differences

## Test plan

- [ ] Compile and install `testprog.te` from lab04 on a kernel 4.13+ system and verify `testprog` no longer segfaults on the `map` denial
- [ ] Confirm the note in lab06 renders correctly in GitHub markdown